### PR TITLE
Updated remove-saucelabs-jobs-by-build to version 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "domify": "1.4.0",
     "faucet": "0.0.1",
-    "remove-saucelabs-jobs-by-build": "1.0.0",
+    "remove-saucelabs-jobs-by-build": "1.0.1",
     "simulate": "0.0.4",
     "tape": "4.2.1",
     "zuul": "git://github.com/defunctzombie/zuul.git#master"


### PR DESCRIPTION
:rocket:

remove-saucelabs-jobs-by-build just published version 1.0.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 7 commits (ahead by 7, behind by 0).
- [659145b](https://github.com/JamesKyburz/remove-saucelabs-jobs-by-build/commit/659145b545181203c830a449a10b987c9797b384): 1.0.1
- [2b986c4](https://github.com/JamesKyburz/remove-saucelabs-jobs-by-build/commit/2b986c4fc04d412740a855109eced3fc95eb30a6): Merge pull request #2 from JamesKyburz/greenkeeper-through2-2.0.0
- [fe6d69f](https://github.com/JamesKyburz/remove-saucelabs-jobs-by-build/commit/fe6d69fac85520deb17a1989edfe29ab3210403b): chore(package): update through2 to version 2.0.0
- [f808cf7](https://github.com/JamesKyburz/remove-saucelabs-jobs-by-build/commit/f808cf70163f5c12430b13809c3eaa019b27e7ee): Merge pull request #1 from JamesKyburz/greenkeeper-pin
- [7897e4e](https://github.com/JamesKyburz/remove-saucelabs-jobs-by-build/commit/7897e4ef91881e57fb548e14f21d0748848e9976): chore(package): pin dependencies
- [77124f3](https://github.com/JamesKyburz/remove-saucelabs-jobs-by-build/commit/77124f390d35c3252ff567a298f55b9dc3298426): Added retries info to readme
- [c77d73e](https://github.com/JamesKyburz/remove-saucelabs-jobs-by-build/commit/c77d73e00ad224f02fa04dd8e0e9fb5f4f5e0d84): Added some travis specific examples

See the [full diff](https://github.com/JamesKyburz/remove-saucelabs-jobs-by-build/compare/4971897cb4c065733c50d1b0fbbc928de48f7246...659145b545181203c830a449a10b987c9797b384).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
